### PR TITLE
Add alias domain name redirects to netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,3 +19,11 @@
   package = "netlify-plugin-hugo-cache-resources"
   [plugins.inputs]
     debug = true
+
+[[redirects]]
+  from = "https://ciselab.netlify.app/*"
+  to = "https://www.ciselab.nl/:splat"
+
+[[redirects]]
+  from = "https://www.ciselab.com/*"
+  to = "https://www.ciselab.nl/:splat"


### PR DESCRIPTION
Currently, the website is reachable under ciselab.netlify.app, ciselab.com, and ciselab.nl. These should all be redirected to the canonical domain name: ciselab.nl